### PR TITLE
Dont run build and test workflow on push to master

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,6 @@
 name: 'Build and Test'
 
 on:
-  push:
-    branches: ['master']
   pull_request:
     branches: ['master']
 


### PR DESCRIPTION
We have a separate Deploy workflow that will build+test+deploy on push to master, so running this workflow is redundant.