### PR TITLE
chore: update @testing-library/react to match React 18 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.2",
-        "@testing-library/react": "^12.1.4",
+        "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "@vitejs/plugin-react": "^4.0.4",
         "jsdom": "^22.1.0",
@@ -1253,21 +1253,21 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.4.tgz",
-      "integrity": "sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
+      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "*"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -4469,14 +4469,14 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.4.tgz",
-      "integrity": "sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
+      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "*"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       }
     },
     "@testing-library/user-event": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^12.1.4",
+    "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@vitejs/plugin-react": "^4.0.4",
     "jsdom": "^22.1.0",


### PR DESCRIPTION
When we upgraded React 18 we forgot to upgrade `@testing-library/react` to match the new version, so now our unit test for App is logging a warning.

https://github.com/wweitzel/top90-frontend/actions/runs/6060072421/job/16443854250#step:6:14

This PR upgrades `@testing-library/react` to v13 which uses React 18