### PR TITLE
chore: fix truncation for selected dropdown option

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -41,7 +41,12 @@ function Select({
             aria-expanded="false"
             data-offset="10,20"
           >
-            {currentOption?.displayName || 'All'}
+            <span
+              className="d-inline-block"
+              style={{maxWidth: '85%', overflowX: 'clip', textOverflow: 'ellipsis'}}
+            >
+              {currentOption?.displayName || 'All'}
+            </span>
           </button>
           <div
             className="dropdown-menu overflow-auto w-100 pt-0"

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -43,7 +43,7 @@ function Select({
           >
             <span
               className="d-inline-block"
-              style={{maxWidth: '85%', overflowX: 'clip', textOverflow: 'ellipsis'}}
+              style={{maxWidth: '90%', overflowX: 'clip', textOverflow: 'ellipsis'}}
             >
               {currentOption?.displayName || 'All'}
             </span>


### PR DESCRIPTION
This PR fixes the truncation of the main dropdowns. The text now gets cut off before the carrot and has an ellipsis to indicate to the user that it is being cut off.

**Before**
<img width="582" alt="Screen Shot 2023-10-08 at 4 59 03 PM" src="https://github.com/wweitzel/top90-frontend/assets/14275198/d4c9d13a-728e-4fe5-963c-6a0e7c1f7f04">

**After**
<img width="753" alt="Screen Shot 2023-10-09 at 3 51 41 PM" src="https://github.com/wweitzel/top90-frontend/assets/14275198/cec26aa7-cb20-4dd0-b164-98da399ea60b">

