### PR TITLE
Send encoded json query param

### DIFF
--- a/src/lib/api/fixtures.ts
+++ b/src/lib/api/fixtures.ts
@@ -17,6 +17,7 @@ export interface Fixture {
 export interface GetFixturesFilter {
   leagueId?: number;
   todayOnly?: boolean;
+  searchTeam?: string;
 }
 
 export interface GetFixturesResponse {
@@ -27,25 +28,19 @@ export interface GetFixtureResponse {
   fixture: Fixture;
 }
 
-export const getFixtures = async (
-  getGoalsFilter: GetFixturesFilter
-): Promise<GetFixturesResponse> => {
-  const {leagueId, todayOnly} = getGoalsFilter;
-
-  let url = `${API_BASE_URL}/fixtures?`;
-  if (leagueId) {
-    url += `leagueId=${leagueId}`;
+export async function getFixtures(filter?: GetFixturesFilter) {
+  if (!filter) {
+    filter = {};
   }
 
-  if (todayOnly) {
-    url += `todayOnly=${todayOnly}`;
-  }
+  const json = encodeURIComponent(JSON.stringify(filter));
+  const url = `${API_BASE_URL}/fixtures?json=${json}`;
 
   const response = await axios.get<GetFixturesResponse>(url);
   return response.data;
-};
+}
 
-export const getFixture = async (id: string): Promise<GetFixtureResponse> => {
+export async function getFixture(id: string) {
   const response = await axios.get<GetFixtureResponse>(`${API_BASE_URL}/fixtures/${id}`);
   return response.data;
-};
+}

--- a/src/lib/api/goals.ts
+++ b/src/lib/api/goals.ts
@@ -25,6 +25,11 @@ export interface GetGoalsFilter {
   fixtureId?: number;
 }
 
+export interface GetGoalsRequest {
+  pagination: Pagination;
+  filter?: GetGoalsFilter;
+}
+
 export interface GetGoalsResponse {
   goals: Goal[];
   total: number;
@@ -34,33 +39,18 @@ export interface GetGoalResponse {
   goal: Goal;
 }
 
-export const getGoals = async (
-  pagination: Pagination = {skip: 0, limit: 5},
-  getGoalsFilter: GetGoalsFilter = {searchTerm: '', leagueId: 0, season: 0, teamId: 0}
-): Promise<GetGoalsResponse> => {
-  let {searchTerm, leagueId, season, teamId, fixtureId} = getGoalsFilter;
-
-  if (!searchTerm) {
-    searchTerm = '';
-  }
-  if (!leagueId) {
-    leagueId = 0;
-  }
-  if (!season) {
-    season = 0;
-  }
-  if (!teamId) {
-    teamId = 0;
-  }
-  if (!fixtureId) {
-    fixtureId = 0;
+export async function getGoals(pagination?: Pagination, filter?: GetGoalsFilter) {
+  if (!pagination) {
+    pagination = {skip: 0, limit: 10};
   }
 
-  const response = await axios.get<GetGoalsResponse>(
-    `${API_BASE_URL}/goals?skip=${pagination.skip}&limit=${pagination.limit}&search=${searchTerm}&leagueId=${leagueId}&season=${season}&teamId=${teamId}&fixtureId=${fixtureId}`
-  );
+  const request: GetGoalsRequest = {pagination, filter};
+  const json = encodeURIComponent(JSON.stringify(request));
+  const url = `${API_BASE_URL}/goals?json=${json}`;
+
+  const response = await axios.get<GetGoalsResponse>(url);
   return response.data;
-};
+}
 
 export const getGoal = async (id: string): Promise<GetGoalResponse> => {
   const response = await axios.get<GetGoalResponse>(`${API_BASE_URL}/goals/${id}`);

--- a/src/lib/api/leagues.ts
+++ b/src/lib/api/leagues.ts
@@ -14,8 +14,8 @@ export interface GetLeaguesResponse {
   leagues: League[];
 }
 
-export const getLeagues = async (): Promise<GetLeaguesResponse> => {
+export async function getLeagues() {
   let url = `${API_BASE_URL}/leagues`;
   const response = await axios.get<GetLeaguesResponse>(url);
   return response.data;
-};
+}

--- a/src/lib/api/teams.ts
+++ b/src/lib/api/teams.ts
@@ -19,13 +19,23 @@ export interface Teams {
   away: Team;
 }
 
+export interface GetTeamsFilter {
+  leagueId?: number;
+  season?: number;
+}
+
 export interface GetTeamsResponse {
   teams: Team[];
 }
 
-export const getTeams = async (leagueId = 0, season = 0) => {
-  const response = await axios.get<GetTeamsResponse>(
-    `${API_BASE_URL}/teams?leagueId=${leagueId}&season=${season}`
-  );
+export async function getTeams(filter?: GetTeamsFilter) {
+  if (!filter) {
+    filter = {};
+  }
+
+  const json = encodeURIComponent(JSON.stringify(filter));
+  const url = `${API_BASE_URL}/teams?json=${json}`;
+
+  const response = await axios.get<GetTeamsResponse>(url);
   return response.data;
-};
+}

--- a/src/pages/Goals.tsx
+++ b/src/pages/Goals.tsx
@@ -19,7 +19,7 @@ const defaultPagination: Pagination = {skip: 0, limit: 5};
 function Goals() {
   const [pagination, setPagination] = useState(defaultPagination);
   const [currentPage, setCurrentPage] = useState(0);
-  const [selectedLeagueId, setSelectedLeagueId] = useState(0);
+  const [selectedLeagueId, setSelectedLeagueId] = useState<number>();
   const [selectedTeamId, setSelectedTeamId] = useState<number>();
   const [selectedSeason, setSelectedSeason] = useState<number>();
   const [searchInput, setSearchInput] = useState('');
@@ -86,14 +86,15 @@ function Goals() {
       searchTerm: searchInput,
       leagueId: parseInt(selectedLeagueId),
       season: selectedSeason,
-      teamId: 0,
     };
     setGetGoalsResponse(undefined);
     getGoals(defaultPagination, getGoalsFilter).then((data) => setGetGoalsResponse(data));
-    getTeams(parseInt(selectedLeagueId), selectedSeason).then((data) => setGetTeamsResponse(data));
+    getTeams({leagueId: parseInt(selectedLeagueId), season: selectedSeason}).then((data) =>
+      setGetTeamsResponse(data)
+    );
 
     setSelectedLeagueId(parseInt(selectedLeagueId));
-    setSelectedTeamId(0);
+    setSelectedTeamId(undefined);
     setPagination(defaultPagination);
     setCurrentPage(0);
   }
@@ -135,9 +136,9 @@ function Goals() {
     getGoals().then((data) => setGetGoalsResponse(data));
     getTeams().then((data) => setGetTeamsResponse(data));
 
-    setSelectedLeagueId(0);
-    setSelectedTeamId(0);
-    setSelectedSeason(0);
+    setSelectedLeagueId(undefined);
+    setSelectedTeamId(undefined);
+    setSelectedSeason(undefined);
     setSearchInput('');
     setCurrentPage(0);
     setPagination(defaultPagination);


### PR DESCRIPTION
We currently make requests with multiple query params like the following:
`https://api.top90.io/goals?skip=0&limit=5&search=&leagueId=0&season=0&teamId=0&fixtureId=0` 

We will now send a single encoded `json` param. Something like the following:
`http://127.0.0.1:7171/goals?json=%7B%22pagination%22%3A%7B%22skip%22%3A0%2C%22limit%22%3A10%7D%7D`.

It is much easier to work with a single request object like that, rather than individual params.