### PR TITLE
fix: add blocking script to load theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
       Learn how to configure a non-root public URL by running `bun run build`.
     -->
     <title>top90.io</title>
+    <script>
+      let storedTheme = localStorage.getItem('top90-theme');
+      if (storedTheme) {
+        document.documentElement.setAttribute('data-bs-theme', storedTheme);
+      }
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/index.html
+++ b/index.html
@@ -29,13 +29,13 @@
       if (storedTheme) {
         document.documentElement.setAttribute('data-bs-theme', storedTheme);
       } else {
-        let preferredTheme = 'light'
+        let preferredTheme = 'light';
 
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-          preferredTheme = 'dark'
+          preferredTheme = 'dark';
         }
 
-        document.documentElement.setAttribute('data-bs-theme', preferredTheme)
+        document.documentElement.setAttribute('data-bs-theme', preferredTheme);
       }
     </script>
   </head>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
     -->
     <title>top90.io</title>
     <script>
+      // We need to load the stored theme in before the body loads in order to
+      // avoid flashing from light to dark theme.
       let storedTheme = localStorage.getItem('top90-theme');
       if (storedTheme) {
         document.documentElement.setAttribute('data-bs-theme', storedTheme);

--- a/index.html
+++ b/index.html
@@ -23,11 +23,19 @@
     -->
     <title>top90.io</title>
     <script>
-      // We need to load the stored theme in before the body loads in order to
-      // avoid flashing from light to dark theme.
-      let storedTheme = localStorage.getItem('top90-theme');
+      // We need to load the theme in before the body loads in order to
+      // avoid flashing from light to dark theme when refreshing.
+      const storedTheme = localStorage.getItem('top90-theme');
       if (storedTheme) {
         document.documentElement.setAttribute('data-bs-theme', storedTheme);
+      } else {
+        let preferredTheme = 'light'
+
+        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          preferredTheme = 'dark'
+        }
+
+        document.documentElement.setAttribute('data-bs-theme', preferredTheme)
       }
     </script>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,7 @@ import Fixture from './pages/Fixture';
 import Goal from './pages/Goal';
 import Goals from './pages/Goals';
 
-import {useEffect} from 'react';
 import {createBrowserRouter, Navigate, RouterProvider} from 'react-router-dom';
-import {getPreferredTheme, setTheme} from './lib/utils';
 
 const router = createBrowserRouter([
   {
@@ -31,11 +29,6 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
-  useEffect(() => {
-    const preferredTheme = getPreferredTheme();
-    setTheme(preferredTheme);
-  }, []);
-
   return <RouterProvider router={router} />;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,7 +4,7 @@ export function getPreferredTheme() {
     return storedTheme;
   }
 
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'light' : 'dark';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
 export function setTheme(theme: string) {


### PR DESCRIPTION
Fixes #92 

Before, we wouldn't set the stored theme until the React bundle was loaded in. The bundle is loaded at the end of the body, so it doesn't block the page rendering. The body would load with the default white color, then the bundle would load in and set the theme. The result is that we'd see a white flash on the screen.

This PR adds a blocking script to the head of the index HTML file that reads the stored theme in from local storage and sets it. This script will run before the document renders, so we won't see a flash. It still happens in dev mode, but not in production.