### PR TITLE
chore: update workflow to use PR head sha instead of merge commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.0.0
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Restore cached dependencies
         id: dependency-restore
         uses: actions/cache/restore@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.0.0
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v3
       - name: Restore cached dependencies
         id: dependency-restore
         uses: actions/cache/restore@v3
@@ -71,7 +69,9 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.0.0
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Restore cached dependencies
         id: dependency-restore
         uses: actions/cache/restore@v3


### PR DESCRIPTION
with our current checkout action, Github will create a merge commit internally and run the action based on this commit - this messes up our Cypress Cloud data because the Action isn't associated with the commit that we pushed up to the Git branch.

This PR updates the action so that it's using the head of the branch that was pushed to 

**TL;DR: This fixes our commit/build association on Cypress Cloud**